### PR TITLE
Add local package in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,7 @@
+# local package
+-e .
+
+# external requirements
 pre-commit==2.21.0
 click
 Sphinx


### PR DESCRIPTION
Commit 29c6147d175aafd667267ed1b64244f058fc7377 removed the following line in `requirements.txt`:
```
-e .
```
This means the code in `src` is not installed as a python package anymore when calling `pip install -r requirements.txt`. Not installing the code as a python package causes imports to fail when calling the scripts from the root directory.

I added back `-e .` back in `requirements.txt`.