### PR TITLE
Ignore model checkpoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,7 +76,7 @@ target/
 .ipynb_checkpoints/
 
 # exclude data from source control by default
-/data/
+/data
 
 # Mac OS-specific storage files
 .DS_Store
@@ -87,7 +87,6 @@ target/
 
 # Mypy cache
 .mypy_cache/
-/data
 
 # model checkpoints
 models/

--- a/.gitignore
+++ b/.gitignore
@@ -88,3 +88,6 @@ target/
 # Mypy cache
 .mypy_cache/
 /data
+
+# model checkpoints
+models/


### PR DESCRIPTION
I propose to remove the directory containing serialized model checkpoints `models/` from source control.

Also removed a duplicate `data/` directory entry in `.gitignore`. I believe this is due to DVC automatically adding a `/data` entry if not already in `.gitignore`, and it did not detect the `/data/` from `cookie-cutter`. Now removed the duplicate and changed `/data/` to `/data`.