### PR TITLE
hydra works as expected

### DIFF
--- a/conf/config.yaml
+++ b/conf/config.yaml
@@ -1,2 +1,0 @@
-defaults:
-  - model

--- a/conf/default.yaml
+++ b/conf/default.yaml
@@ -1,0 +1,2 @@
+dataset:
+  output_filepath: data/processed

--- a/conf/model.yaml
+++ b/conf/model.yaml
@@ -1,6 +1,10 @@
-train-hyper-parameters:
+hyperparameters:
   learning_rate: 0.01
   weight_decay: 5e4
   epochs: 100
   hidden_channels: 16
-  wandb: false
+  wandb_log: True
+
+predict_parameters:
+  model_checkpoint: models/trained_model.pt
+  wandb_log: True

--- a/readme.md
+++ b/readme.md
@@ -53,6 +53,13 @@ conda env create -n mlops --file environment-m1.yml
 if it still fails.. Run the `utilities/conda-torch-m1.sh` shell script in a fresh conda environment. And then continue to install your packages as usual.
 - Remember to make the script executable i.e., `chmod +x utilities/conda-torch-m1.sh`..
 
+### Install MLOps Command-Line Interface
+Check out the `mlops` cli. Installed like so:
+```sh
+python -m pip install -e .
+```
+making it easy to run commands like `mlops train` to train the model..
+
 # Project checklist
 
 ## Week 1

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,3 +23,4 @@ matplotlib
 wandb
 python-dotenv
 pytest
+fire

--- a/setup.py
+++ b/setup.py
@@ -7,4 +7,7 @@ setup(
     description="Mandatory project for 02476 MLOps course at DTU. Project scope to be determined.",
     author="Spyros-Benjamin-Jens-Philippe",
     license="",
+    entry_points = {
+        'console_scripts': ['mlops=src.scripts.command_line:main']
+    }
 )

--- a/src/data/make_dataset.py
+++ b/src/data/make_dataset.py
@@ -1,18 +1,18 @@
 # -*- coding: utf-8 -*-
 import os
 import logging
-import click
 import torch
-from pathlib import Path
 import shutil
+import hydra
 
+from pathlib import Path
+from omegaconf import DictConfig
 from torch_geometric.datasets import Planetoid
 from torch_geometric.transforms import NormalizeFeatures
 
 
-@click.command()
-@click.argument("output_filepath", type=click.Path())
-def main(output_filepath):
+@hydra.main(version_base=None, config_path="../../conf", config_name="default")
+def main(cfg: DictConfig) -> None:
     """Runs data processing scripts to turn raw data from (../raw) into
     cleaned data ready to be analyzed (saved in ../processed).
     """
@@ -21,7 +21,7 @@ def main(output_filepath):
     dataset = Planetoid(root="data", name="Cora", transform=NormalizeFeatures())
     logger.info("Download completed")
 
-    outpath = os.path.join(output_filepath, "data.pt")
+    outpath = os.path.join(cfg.dataset.output_filepath, "data.pt")
     torch.save(dataset, outpath)
 
     logger.info("Delete data folder created by Planetoid function")

--- a/src/models/predict_model.py
+++ b/src/models/predict_model.py
@@ -1,14 +1,14 @@
 import logging
-
-import click
+import hydra
 import torch
+
+from omegaconf import DictConfig
 from src.models.model import GCN
 
-
-@click.command()
-@click.argument("model_checkpoint", type=click.Path(exists=True))
-@click.option("--wandb", "wandb_log", is_flag=True)
-def main(model_checkpoint, wandb_log):
+@hydra.main(version_base=None, config_path="../../conf", config_name="model")
+def main(cfg: DictConfig) -> None:
+    wandb_log = cfg.predict_parameters.wandb_log
+    model_checkpoint = cfg.predict_parameters.model_checkpoint
     logger = logging.getLogger(__name__)
 
     logger.info("loading model")

--- a/src/models/train_model.py
+++ b/src/models/train_model.py
@@ -1,19 +1,22 @@
 import logging
 import os
 
-import click
 import matplotlib.pyplot as plt
 import torch
 import wandb
+import hydra
 
 from src.models.model import GCN
 
-@click.command(context_settings={"show_default": True})
-@click.option("--lr", default=0.01)
-@click.option("--wd", default=5e4)
-@click.option("--epochs", default=100)
-@click.option("--wandb", "wandb_log", is_flag=True)
-def main(lr, wd, epochs, wandb_log):
+from omegaconf import DictConfig
+
+@hydra.main(version_base=None, config_path="../../conf", config_name="model")
+def main(cfg: DictConfig) -> None:
+    lr = cfg.hyperparameters.learning_rate
+    wd = cfg.hyperparameters.weight_decay
+    epochs = cfg.hyperparameters.epochs
+    wandb_log = cfg.hyperparameters.wandb_log
+
     logger = logging.getLogger(__name__)
 
     if wandb_log:
@@ -52,7 +55,7 @@ def main(lr, wd, epochs, wandb_log):
         if epoch % 10 == 0:
             logger.info(f"Epoch {epoch}; loss: {loss:.4f}")
             if wandb_log:
-                wandb_log({"loss": loss})
+                wandb.log({'loss': loss})
 
     outdir = "models"
     if not os.path.exists(outdir):

--- a/src/scripts/command_line.py
+++ b/src/scripts/command_line.py
@@ -1,0 +1,14 @@
+import fire
+
+from src.models.train_model import main as train_model
+
+
+def welcome():
+    print("MLOps Group 12: CLI Tool")
+
+
+def main():
+    fire.Fire({
+        'welcome': welcome,
+        'train': train_model
+    })


### PR DESCRIPTION
Hydra works for `make_dataset`, `train_model`, `predict_model`.

Click should be obsolete now, so we can remove it from the `requirements.txt` in favour of hydra.

Further more, I've initialised setup tools entrypoint for a `mlops` command-line interface (just for fun). I usually prefer this way, instead of a make file since it stays in python idiom.