### PR TITLE
Add PyG URL to requirements.txt

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,9 @@ requirements: test_environment
 
 requirements_tests: test_environment
 	$(PYTHON_INTERPRETER) -m pip install -U pip setuptools wheel
+ifeq (False,$(HAS_CONDA))
+	$(PYTHON_INTERPRETER) -m pip install torch-geometric torch-sparse torch-scatter -f https://data.pyg.org/whl/torch-1.13.0+cpu.html
+endif
 	$(PYTHON_INTERPRETER) -m pip install -r requirements.txt
 	$(PYTHON_INTERPRETER) -m pip install -r requirements_tests.txt
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,7 @@ nbdev
 black
 numpy
 torch
+-f https://data.pyg.org/whl/torch-1.13.0+cu117.html
 torch-geometric
 torch-sparse
 torch-scatter


### PR DESCRIPTION
On a fresh env, installing `torch-geometric`, `torch-sparse` and `torch-scatter` via `pip install -r requirements.txt` fails because they depend on `torch` (see [this issue](https://github.com/pyg-team/pytorch_geometric/issues/861) on PyG repo).

Solution is to specify the URL. 