### PR TITLE
Fix long workflows

### DIFF
--- a/.github/workflows/main-pull-request.yml
+++ b/.github/workflows/main-pull-request.yml
@@ -34,8 +34,6 @@ jobs:
           restore-keys: |
             ${{ matrix.os }}-pip-
 
-      - name: install torch (work around for torch-sparse)
-        run: pip install torch
       - name: install test dependencies
         run: make requirements_tests
       - uses: iterative/setup-dvc@v1

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ requirements_tests: test_environment
 	$(PYTHON_INTERPRETER) -m pip install -U pip setuptools wheel
 ifeq ($(OS),Windows_NT)
 	$(PYTHON_INTERPRETER) -m pip install torch-geometric torch-sparse torch-scatter -f https://data.pyg.org/whl/torch-1.13.0+cpu.html
-else ifeq ($(UNAME), Darwin)
+else ifeq ($(shell uname), Darwin)
 	$(PYTHON_INTERPRETER) -m pip install torch
 endif
 	$(PYTHON_INTERPRETER) -m pip install -r requirements.txt

--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,8 @@ requirements_tests: test_environment
 	$(PYTHON_INTERPRETER) -m pip install -U pip setuptools wheel
 ifeq ($(OS),Windows_NT)
 	$(PYTHON_INTERPRETER) -m pip install torch-geometric torch-sparse torch-scatter -f https://data.pyg.org/whl/torch-1.13.0+cpu.html
+else ifeq ($(UNAME), Darwin)
+	$(PYTHON_INTERPRETER) -m pip install torch
 endif
 	$(PYTHON_INTERPRETER) -m pip install -r requirements.txt
 	$(PYTHON_INTERPRETER) -m pip install -r requirements_tests.txt

--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,7 @@ requirements_tests: test_environment
 ifeq ($(OS),Windows_NT)
 	$(PYTHON_INTERPRETER) -m pip install torch-geometric torch-sparse torch-scatter -f https://data.pyg.org/whl/torch-1.13.0+cpu.html
 else ifeq ($(shell uname -s), Darwin)
+	$(PYTHON_INTERPRETER) -m pip install torch-geometric torch-sparse torch-scatter -f https://data.pyg.org/whl/torch-1.13.0+cpu.html
 	$(PYTHON_INTERPRETER) -m pip install torch
 endif
 	$(PYTHON_INTERPRETER) -m pip install -r requirements.txt

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ requirements_tests: test_environment
 	$(PYTHON_INTERPRETER) -m pip install -U pip setuptools wheel
 ifeq ($(OS),Windows_NT)
 	$(PYTHON_INTERPRETER) -m pip install torch-geometric torch-sparse torch-scatter -f https://data.pyg.org/whl/torch-1.13.0+cpu.html
-else ifeq ($(shell uname), Darwin)
+else ifeq ($(shell uname -s), Darwin)
 	$(PYTHON_INTERPRETER) -m pip install torch
 endif
 	$(PYTHON_INTERPRETER) -m pip install -r requirements.txt

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ requirements: test_environment
 
 requirements_tests: test_environment
 	$(PYTHON_INTERPRETER) -m pip install -U pip setuptools wheel
-ifeq (False,$(HAS_CONDA))
+ifeq ($(OS),Windows_NT)
 	$(PYTHON_INTERPRETER) -m pip install torch-geometric torch-sparse torch-scatter -f https://data.pyg.org/whl/torch-1.13.0+cpu.html
 endif
 	$(PYTHON_INTERPRETER) -m pip install -r requirements.txt


### PR DESCRIPTION
Trying to fix very long workflows due to the `torch-sparse` install taking ages. This was partially solved in #31 by specifying the install URL, but it was still broken for the MacOS workflow.

Also removed the torch pre-install workaround as #31 fixed it.