### PR TITLE
Implement Vertex AI support with GCS bucket

### DIFF
--- a/conf/config.yaml
+++ b/conf/config.yaml
@@ -1,0 +1,11 @@
+hyperparameters:
+  learning_rate: 0.01
+  weight_decay: 5e4
+  epochs: 100
+  hidden_channels: 16
+
+checkpoint: models/trained_model.pt
+
+dataset: data/processed/data.pt
+
+wandb: False

--- a/conf/default.yaml
+++ b/conf/default.yaml
@@ -1,2 +1,0 @@
-dataset:
-  output_filepath: data/processed

--- a/conf/model.yaml
+++ b/conf/model.yaml
@@ -1,9 +1,0 @@
-hyperparameters:
-  learning_rate: 0.01
-  weight_decay: 5e4
-  epochs: 100
-  hidden_channels: 16
-
-checkpoint: models/trained_model.pt
-
-wandb: False

--- a/src/data/make_dataset.py
+++ b/src/data/make_dataset.py
@@ -11,7 +11,7 @@ from torch_geometric.datasets import Planetoid
 from torch_geometric.transforms import NormalizeFeatures
 
 
-@hydra.main(version_base=None, config_path="../../conf", config_name="default")
+@hydra.main(version_base=None, config_path="../../conf", config_name="config")
 def main(cfg: DictConfig) -> None:
     """Runs data processing scripts to turn raw data from (../raw) into
     cleaned data ready to be analyzed (saved in ../processed).
@@ -21,7 +21,7 @@ def main(cfg: DictConfig) -> None:
     dataset = Planetoid(root="data", name="Cora", transform=NormalizeFeatures())
     logger.info("Download completed")
 
-    outpath = os.path.join(cfg.dataset.output_filepath, "data.pt")
+    outpath = os.path.join(cfg.dataset)
     torch.save(dataset, outpath)
 
     logger.info("Delete data folder created by Planetoid function")

--- a/src/models/predict_model.py
+++ b/src/models/predict_model.py
@@ -6,7 +6,7 @@ from omegaconf import DictConfig
 from src.models.model import GCN
 
 
-@hydra.main(version_base=None, config_path="../../conf", config_name="model")
+@hydra.main(version_base=None, config_path="../../conf", config_name="config")
 def main(cfg: DictConfig) -> None:
     # wandb_log = cfg.wandb
     model_checkpoint = cfg.checkpoint
@@ -19,7 +19,7 @@ def main(cfg: DictConfig) -> None:
     model.eval()
 
     logger.info("loading data")
-    data = torch.load("data/processed/data.pt")[0]  # access first and only graph
+    data = torch.load(cfg.dataset)[0]  # access first and only graph
 
     logger.info("predicting")
     out = model(data.x, data.edge_index)

--- a/src/models/train_model.py
+++ b/src/models/train_model.py
@@ -11,7 +11,7 @@ from src.models.model import GCN
 from omegaconf import DictConfig
 
 
-@hydra.main(version_base=None, config_path="../../conf", config_name="model")
+@hydra.main(version_base=None, config_path="../../conf", config_name="config")
 def main(cfg: DictConfig) -> None:
     lr = cfg.hyperparameters.learning_rate
     wd = cfg.hyperparameters.weight_decay
@@ -32,7 +32,7 @@ def main(cfg: DictConfig) -> None:
     criterion = torch.nn.CrossEntropyLoss()
 
     logger.info("loading data")
-    data = torch.load("data/processed/data.pt")[0]  # access first and only graph
+    data = torch.load(cfg.dataset)[0]  # access first and only graph
 
     if wandb_log:
         wandb.watch(model)

--- a/trainer.dockerfile
+++ b/trainer.dockerfile
@@ -14,14 +14,15 @@ RUN apt update && \
 COPY requirements.txt ./requirements.txt
 COPY setup.py ./setup.py
 COPY src/ ./src/
-ADD data.dvc ./data.dvc
-ADD models.dvc ./models.dvc
-ADD .dvc/ ./.dvc/
-ADD .git/ ./.git/
+COPY conf/ ./conf/
+# ADD data.dvc ./data.dvc
+# ADD models.dvc ./models.dvc
+# ADD .dvc/ ./.dvc/
+# ADD .git/ ./.git/
 
 RUN python -m pip install --upgrade pip
 #necessary to install torch before torch-scatter, torch-sparse... workaround...
 RUN pip install torch
 RUN pip install -r requirements.txt --no-cache-dir
 
-RUN dvc pull
+# RUN dvc pull

--- a/vertex_jobspec.yaml
+++ b/vertex_jobspec.yaml
@@ -1,0 +1,13 @@
+workerPoolSpecs:
+   machineSpec:
+      machineType: n1-highmem-2
+   replicaCount: 1
+   containerSpec:
+      imageUri: gcr.io/hybrid-essence-236114/trainer
+      command:
+         - python
+         - -u
+         - src/models/train_model.py
+      args: 
+         - dataset=/gcs/user-friendly-data/data.pt
+         - checkpoint=/gcs/user-friendly-data/train_model.pt


### PR DESCRIPTION
Merged both hydra config files into a single one. One had a single option which was the dataset path and which can actually be used in both the make data script and the train script.

Now that this is a CLI argument in the train script it is possible to point to a GCS bucket when running Vertex jobs.

Also removed DVC pull command from dockerfile in favor of mounting a GCS bucket when running Vertex jobs.

Added Vertex job configuration file. The Vertex job can be ran using
```
gcloud ai custom-jobs create --region=europe-west1 --display-name=training_job --config=vertex_jobspec.yaml 
```