### PR TITLE
Update Vertex AI jobspec with new checkpoint name

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,9 +45,14 @@ Make a single prediction:
 python src/models/predict.py <item-index-in-dataset>
 ```
 
-Run unittests with coverage
+Run unittests with coverage:
 ```
 coverage run --source=src/ -m pytest tests/
+```
+
+Submit training job to Vertex AI:
+```
+gcloud ai custom-jobs create --region=europe-west1 --display-name=training_job --config=vertex_jobspec.yaml
 ```
 
 ### Configure Torch on M1 (FIX)

--- a/vertex_jobspec.yaml
+++ b/vertex_jobspec.yaml
@@ -10,4 +10,4 @@ workerPoolSpecs:
          - src/models/train_model.py
       args: 
          - dataset=/gcs/user-friendly-data/data.pt
-         - checkpoint=/gcs/user-friendly-data/train_model.pt
+         - checkpoint=/gcs/user-friendly-data/checkpoint.pt


### PR DESCRIPTION
PR #39 changed the default checkpoint name but this was not updated in the Vertex jobspec. This PR fixes this.

Also added the command to submit the training job in README.md