### PR TITLE
Fix Vertex AI jobspec and fix wandb flag

### DIFF
--- a/src/models/train.py
+++ b/src/models/train.py
@@ -64,7 +64,7 @@ def main(cfg: DictConfig) -> None:
     plt.xlabel("Epoch")
     plt.ylabel("Loss")
     plt.savefig(os.path.join(ckpt_dir, "training_curve.png"))
-    plt.show()
+    # plt.show()
 
 
 if __name__ == "__main__":

--- a/vertex_jobspec.yaml
+++ b/vertex_jobspec.yaml
@@ -7,7 +7,7 @@ workerPoolSpecs:
       command:
          - python
          - -u
-         - src/models/train_model.py
+         - src/models/train.py
       args: 
          - dataset=/gcs/user-friendly-data/data.pt
          - checkpoint=/gcs/user-friendly-data/checkpoint.pt


### PR DESCRIPTION
PR #39 changed the name of the training script but this was not updated in the Vertex jobspec. This PR fixes this.

Also fixing ignored wandb flag when initializing Lightning's wandb logger.

Also commenting out `plt.show` at end of training script.