### PR TITLE
Fix make_dataset failing when data dir does not exist

### DIFF
--- a/src/data/make_dataset.py
+++ b/src/data/make_dataset.py
@@ -22,6 +22,9 @@ def main(cfg: DictConfig) -> None:
     logger.info("Download completed")
 
     outpath = os.path.join(cfg.dataset)
+    dirpath = os.path.dirname(outpath)
+    if not os.path.exists(dirpath):
+        os.makedirs(dirpath)
     torch.save(dataset, outpath)
 
     logger.info("Delete data folder created by Planetoid function")


### PR DESCRIPTION
If the `data` dir does not exist, the make dataset script fails. This is the case when working after a fresh `git clone`, since the `.gitkeep` files in `data` were removed. This PR fixes this by creating the directory if it does not exist.