### PR TITLE
Fix extension of checkpoint in vertex jobspec

### DIFF
--- a/vertex_jobspec.yaml
+++ b/vertex_jobspec.yaml
@@ -10,4 +10,4 @@ workerPoolSpecs:
          - src/models/train.py
       args:
          - dataset=/gcs/user-friendly-data/data.pt
-         - checkpoint=/gcs/user-friendly-data/checkpoint.pt
+         - checkpoint=/gcs/user-friendly-data/checkpoint.ckpt


### PR DESCRIPTION
The extension of the checkpoint file in the Vertex jobspec was wrong. Changed it from `.pt` to `.ckpt`.