### PR TITLE
Update DVC metafiles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,7 +90,7 @@ target/
 .mypy_cache/
 
 # model checkpoints
-/models/
+/models
 
 #wandb
 wandb

--- a/data.dvc
+++ b/data.dvc
@@ -1,5 +1,5 @@
 outs:
-- md5: 6c4faa8a166405101ad73fe2f7070a6c.dir
+- md5: f83d645cfce90c1cc30668b5ac5f323f.dir
   size: 15723391
-  nfiles: 5
+  nfiles: 1
   path: data

--- a/models.dvc
+++ b/models.dvc
@@ -1,5 +1,5 @@
 outs:
-- md5: b33f0c24031086e6b98d6fb1a62d80bf.dir
-  size: 116436
-  nfiles: 3
+- md5: 0ce8ca688acb05ec197226ae89aa7302.dir
+  size: 313317
+  nfiles: 2
   path: models


### PR DESCRIPTION
Updated DVC metafiles to match the new checkpoint file. Also removed `.gitkeep` files that were still on the DVC remote.

After a `dvc pull` on a fresh clone, the content of `data` and `models` now looks like this:
```
data
└── processed
    └── data.pt
models
├── checkpoint.ckpt
└── training_curve.png
```